### PR TITLE
Re-render and remove the pin to fiona 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@ env:
 
 
 before_install:
+    # Remove homebrew.
     - brew remove --force $(brew list)
+    - brew cleanup -s
+    - rm -rf $(brew --cache)
 
 install:
     - |
@@ -26,7 +29,7 @@ install:
 
       conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build jinja2 anaconda-client
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,6 +54,10 @@ install:
     - cmd: conda config --add channels http://conda.binstar.org/conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
+    # Workaround for Python 3.4 and x64 bug in latest conda-build.
+    # FIXME: Remove once there is a release that fixes the upstream issue
+    # ( https://github.com/conda/conda-build/issues/895 ).
+    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
 
 # Skip .NET project specific build phase.
 build: off

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,14 +17,14 @@ build:
 requirements:
     build:
         - python
-        - fiona 1.6.3
+        - fiona
         - netcdf4
         - numpy
         - shapely
     run:
         - python
         - cf_units
-        - fiona 1.6.3
+        - fiona
         - netcdf4
         - numpy
         - shapely


### PR DESCRIPTION
Pinning `fiona` does not solve the issue of the getting the broken `fiona` from the default channel. Right now the only workaround is to ensure our is the latest version with a higher build number than the default channel.