### PR TITLE
FIX: Update proj.4 package name

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: d76ca32d81bdf52a71dde48a7641085ff280b9d9fea0a294fda3308942ca5230
 
 build:
-    number: 0
+    number: 1
     skip: True  # [py3k]
     script: python setup.py install --single-version-externally-managed --record record.txt
 


### PR DESCRIPTION
- Incrementing build number to refresh package dependencies.
- Install was still trying to find "proj.4".